### PR TITLE
Set resourceItem size to comply with latest nvrhi requirements.

### DIFF
--- a/libraries/omm-gpu-nvrhi/omm-gpu-nvrhi.cpp
+++ b/libraries/omm-gpu-nvrhi/omm-gpu-nvrhi.cpp
@@ -475,6 +475,7 @@ void GpuBakeNvrhiImpl::SetupPipelines(
 				break;
 			}
 
+			resourceItem.size = 1;
 			for (uint32_t descriptorOffset = 0; descriptorOffset < descriptorRange.descriptorNum; descriptorOffset++)
 			{
 				resourceItem.slot = descriptorRange.baseRegisterIndex + descriptorOffset;


### PR DESCRIPTION
Latest version of NVRHI expect all BindingLayoutItems to have a non zero size.